### PR TITLE
Expose client in connection and manager

### DIFF
--- a/src/Rizeway/OREM/Connection/ConnectionInterface.php
+++ b/src/Rizeway/OREM/Connection/ConnectionInterface.php
@@ -9,6 +9,11 @@ interface ConnectionInterface
     const METHOD_DELETE = 'DELETE';
     const METHOD_POST = 'POST';
 
+	/**
+	 * @return mixed
+	 */
+	public function getClient();
+
     /**
      * @param string $method
      * @param string $resource

--- a/src/Rizeway/OREM/Manager.php
+++ b/src/Rizeway/OREM/Manager.php
@@ -205,4 +205,12 @@ class Manager
 
         throw new \Exception('No Mapping Entity found for class : '. get_class($object));
     }
+
+	/**
+	 * @return Connection\ConnectionInterface
+	 */
+	public function getConnection()
+	{
+		return $this->connection;
+	}
 }

--- a/test/unit/Rizeway/OREM/Manager.php
+++ b/test/unit/Rizeway/OREM/Manager.php
@@ -43,6 +43,7 @@ class Manager extends atoum\test
             ->and($object = new TestedClass($connection, array()))
             ->then
                 ->object($object)->isInstanceOf('Rizeway\\OREM\\Manager')
+				->object($object->getConnection())->isIdenticalTo($connection)
         ;
     }
 


### PR DESCRIPTION
This would allow things like this :

``` php
$factory = new \Rizeway\OREM\Config\Factory(__DIR__ . DIRECTORY_SEPARATOR . 'OREM' . DIRECTORY_SEPARATOR . 'Mappings', 'https://api.domain.tld/');
$manager = $factory->getManager();
$client = $manager->getConnection()->getClient();

$client->getDefaultHeaders()->add('Authorization', 'AUTH_TOKEN');
```
